### PR TITLE
add support for the name attr on select

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Visit the [docs site](http://tedconf.github.io/ember-ted-select/) for demos and 
       <td><code>false</code></td>
     </tr>
     <tr>
+      <td><code>name</code></td>
+      <td>[optional] Add a name attribute to the select element.</td>
+      <td>string, null</td>
+      <td><code>null</code></td>
+    </tr>
+    <tr>
       <td><code>selectClassNames</code></td>
       <td>Adds one or more custom class names to the select element. Pass multiple classes as a space separated list: <code>form-control My-select</code></td>
       <td>string, null</td>

--- a/addon/components/ted-select.js
+++ b/addon/components/ted-select.js
@@ -16,6 +16,7 @@ export default Ember.Component.extend({
   sortBy: null,
   multiple: false,
   disabled: false,
+  name: null,
 
   sortArray: Ember.computed('sortBy', function(){
     if (this.get('sortBy')){
@@ -43,7 +44,7 @@ export default Ember.Component.extend({
           return Ember.get(option, this.get('optionValueKey')).toString() === value;
         });
       }
-      
+
       if (this.attrs.onchange){
         this.attrs.onchange(selection);
       }

--- a/addon/templates/components/ted-select.hbs
+++ b/addon/templates/components/ted-select.hbs
@@ -2,7 +2,8 @@
   onchange={{action "onChange" value="target"}}
   class={{selectClassNames}}
   multiple={{multiple}}
-  disabled={{disabled}}>
+  disabled={{disabled}}
+  name={{name}}>
   {{#if prompt}}
   <option
     value=""

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -36,6 +36,7 @@
   {{examples/sorting-options TEDevents=TEDevents}}
   {{examples/disabling-options TEDevents=TEDevents}}
   {{examples/disabled-input TEDevents=TEDevents}}
+  {{examples/named-input TEDevents=TEDevents}}
   {{examples/multi-select TEDevents=TEDevents}}
   {{examples/two-way-bound TEDevents=TEDevents}}
 
@@ -112,6 +113,12 @@
         <td>[optional] Pass a boolean value in to disabled the entire input.</td>
         <td>boolean</td>
         <td><code>false</code></td>
+      </tr>
+      <tr>
+        <td><code>name</code></td>
+        <td>[optional] Add a name sttribute to the select element.</td>
+        <td>string, null</td>
+        <td><code>null</code></td>
       </tr>
       <tr>
         <td><code>selectClassNames</code></td>

--- a/tests/dummy/app/pods/components/examples/named-input/component.js
+++ b/tests/dummy/app/pods/components/examples/named-input/component.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  name: 'awesome-ted-select',
+  TEDevents: [],
+});

--- a/tests/dummy/app/pods/components/examples/named-input/template.hbs
+++ b/tests/dummy/app/pods/components/examples/named-input/template.hbs
@@ -1,0 +1,18 @@
+<h3>Named input</h3>
+<p>You can set the name attribute on the input by passing in a string value to <code>name</code>.</p>
+
+<div class="row">
+  <div class="col-md-6">
+    {{code-snippet name="named-input.hbs"}}
+  </div>
+
+  <div class="col-md-6">
+    {{!-- BEGIN-SNIPPET named-input --}}
+    {{ted-select
+      content=TEDevents
+      selectClassNames="form-control"
+      name="awesome-ted-select"
+    }}
+    {{!-- END-SNIPPET --}}
+  </div>
+</div>

--- a/tests/integration/components/ted-select-test.js
+++ b/tests/integration/components/ted-select-test.js
@@ -118,6 +118,16 @@ test('can disable the input', function(assert) {
   assert.ok(this.$('select').prop('disabled'));
 });
 
+test('can set a name attribute on the input', function(assert) {
+  assert.expect(1);
+  this.set('content', options);
+  this.set('name', 'awesome-ted-select');
+
+  this.render(hbs`{{ted-select content=content name=name}}`);
+
+  assert.equal(this.$('select').prop('name'), 'awesome-ted-select');
+});
+
 test('can pass in an initial selection', function(assert) {
   assert.expect(1);
   this.set('content', options);


### PR DESCRIPTION
PR for #27. I think this should cover it, @brenna.

```hbs
{{ted-select
  content=TEDevents
  selectClassNames="form-control"
  name="awesome-ted-select"
}}
```

generates:

```html
<div id="ember483" class="ember-view Ted-select">
  <select class="form-control" name="awesome-ted-select">
  ...
  </select>
</div>
```

LMK if anything needs changes! :v: