### PR TITLE
add a selectId option to set the select element id

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A data down, actions up select component rendered with real DOM elements.Supports disabled options, multi-select, option sorting and custom prompt.
 
-> This addon is prepared for internal use at TED. We're happy to share our code as open-source, but be aware that it may not be maintianed for broader community use. 
+> This addon is prepared for internal use at TED. We're happy to share our code as open-source, but be aware that it may not be maintianed for broader community use.
 
 ## Installation
 
@@ -113,6 +113,12 @@ Visit the [docs site](http://tedconf.github.io/ember-ted-select/) for demos and 
     <tr>
       <td><code>selectClassNames</code></td>
       <td>Adds one or more custom class names to the select element. Pass multiple classes as a space separated list: <code>form-control My-select</code></td>
+      <td>string, null</td>
+      <td><code>null</code></td>
+    </tr>
+    <tr>
+      <td><code>selectId</code></td>
+      <td>Sets the ID on the select element.</td>
       <td>string, null</td>
       <td><code>null</code></td>
     </tr>

--- a/addon/components/ted-select.js
+++ b/addon/components/ted-select.js
@@ -7,6 +7,7 @@ export default Ember.Component.extend({
 
   classNames: 'Ted-select',
   selectClassNames: null,
+  selectId: null,
   content: Ember.A([]),
   optionValueKey: 'id',
   optionLabelKey: 'title',

--- a/addon/templates/components/ted-select.hbs
+++ b/addon/templates/components/ted-select.hbs
@@ -1,5 +1,6 @@
 <select
   onchange={{action "onChange" value="target"}}
+  id={{selectId}}
   class={{selectClassNames}}
   multiple={{multiple}}
   disabled={{disabled}}

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -127,6 +127,12 @@
         <td><code>null</code></td>
       </tr>
       <tr>
+        <td><code>selectId</code></td>
+        <td>Sets the ID on the select element.</td>
+        <td>string, null</td>
+        <td><code>null</code></td>
+      </tr>
+      <tr>
       </tr>
       <tr>
         <td><code>prompt</code></td>

--- a/tests/dummy/app/pods/components/examples/adding-styles/template.hbs
+++ b/tests/dummy/app/pods/components/examples/adding-styles/template.hbs
@@ -5,6 +5,8 @@
 
   For convenience, the class name on the select element itself can be changed using the `selectClassNames` option. This is helpful for applying framework styles, like [Bootstrap's `.form-control` class](http://getbootstrap.com/css/#forms), shown here and in the following examples.
 
+  You can also customize the select element's ID using the `selectId` option.
+
   You can customize the prompt text with `prompt="your custom string"` or remove it completely with `prompt=null`.
 {{/ember-markdown-section}}
 
@@ -17,6 +19,7 @@
     {{!-- BEGIN-SNIPPET styled --}}
      {{ted-select
       selectClassNames="form-control"
+      selectId="ted-events-select"
       prompt="Choose an event"
       content=TEDevents }}
     {{!-- END-SNIPPET --}}

--- a/tests/integration/components/ted-select-test.js
+++ b/tests/integration/components/ted-select-test.js
@@ -38,7 +38,7 @@ var options= Ember.A([{
 
 test('it renders a select element', function(assert) {
 
-  assert.expect(6);
+  assert.expect(7);
 
   this.set('content', options);
 
@@ -49,6 +49,9 @@ test('it renders a select element', function(assert) {
 
   assert.equal($component.find('select').length, 1);
   assert.equal($options.not('.Ted-select__prompt').length, options.length);
+
+  // renders the select with no id
+  assert.equal($component.find('select').prop('id'), '', 'select has no id');
 
   //renders with a prompt by default
   assert.equal($component.find('.Ted-select__prompt').length, 1);
@@ -233,6 +236,14 @@ test('can create a two way binding on the selection', function(assert) {
 
   assert.equal(this.get('selection'), itemToSelect);
 
+});
+
+test('can add a custom ID to the select element', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{ted-select content=content selectId="my-select"}}`);
+
+  assert.equal(this.$('select#my-select').length, 1);
 });
 
 test('can add a custom class name to the select element', function(assert) {


### PR DESCRIPTION
I wanted to be able to set an element ID on the `select` element so that I could make it match the `for` property on the associated `label`.

Cheers :v: